### PR TITLE
fix: update telegraf install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,9 +28,9 @@ cp boring.sh /usr/local/bin/boring.sh
 systemctl enable boring
 
 echo installing influx
-wget -q https://repos.influxdata.com/influxdb.key
-echo '23a1c8836f0afc5ed24e0486339d7cc8f6790b83886c4c96995b88a061c5bb5d influxdb.key' | sha256sum -c && cat influxdb.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdb.gpg > /dev/null
-echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdb.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 
 apt-get update
 apt-get install -y telegraf


### PR DESCRIPTION
Telegraf has a new install method and key as per https://github.com/influxdata/telegraf/blob/master/README.md#package-repository